### PR TITLE
Rename commands to follow naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ It contains settings file:
 
 and following commands:
 
-* FluentAddMigration
-* FluentUpdateDatabase
-* FluentRollbackDatabase
+* Add-FluentMigration
+* Update-FluentDatabase
+* Rollback-FluentDatabase
 
 ### How to install?
 Please install [FluentMigrator](https://github.com/schambers/fluentmigrator) first.
@@ -48,13 +48,13 @@ Example:
 * **TimeFormat** - time format is a number which will be used for migration number and part of the file name. Time format *"yyMMddHHmm"* also applicable but contains less characters.
 
 
-### FluentAddMigration
+### Add-FluentMigration
 This command generates a new empty migration with a number based on current time with specified time format in **migrations.json**.
 
 It creates migration folder if it does not exist.
 
 ```console
-PM > FluentAddMigration InitialMigration
+PM > Add-FluentMigration InitialMigration
 ```
 
 The migration file will look like this:
@@ -78,18 +78,18 @@ namespace DbMigrations.Migrations
 }  
 ```
 
-### FluentUpdateDatabase
+### Update-FluentDatabase
 
 This command will apply all recently created migrations.
 
 ```console
-PM > FluentUpdateDatabase
+PM > Update-FluentDatabase
 ```
 
-### FluentRollbackDatabase
+### Rollback-FluentDatabase
 
 This command will revert all migrations to specified version (migration number).
 
 ```console
-PM > FluentRollbackDatabase 20191207220215
+PM > Rollback-FluentDatabase 20191207220215
 ```

--- a/src/FluentMigrator.VStudio.psm1
+++ b/src/FluentMigrator.VStudio.psm1
@@ -40,7 +40,7 @@ function GetProjectProperties($projectName)
 	return $o
 }
 
-function FluentUpdateDatabase($projectName)
+function Update-FluentDatabase($projectName)
 {
 	$migrationProject = GetProjectProperties $projectName
 	FluentBuild $migrationProject.Project
@@ -62,7 +62,7 @@ function FluentUpdateDatabase($projectName)
 	Invoke-Expression -Command $command
 }
 
-function FluentRollbackDatabase
+function Rollback-FluentDatabase
 {
 	[CmdletBinding(DefaultParameterSetName = 'MigrationNumber')]
 		param ([parameter(Position = 0, Mandatory = $true)]
@@ -109,7 +109,7 @@ function FluentBuild
 	Write-Output "'$($project.ProjectName)' project build success."
 }
 
-function FluentAddMigration
+function Add-FluentMigration
 {
 	[CmdletBinding(DefaultParameterSetName = 'MigrationName')]
     param (
@@ -183,9 +183,6 @@ namespace $namespace
 }
 
 
-Export-ModuleMember @('FluentUpdateDatabase')
-Export-ModuleMember @('FluentRollbackDatabase')
-Export-ModuleMember @('FluentAddMigration')
-
-# TODO
-# - Check if new migration already exists
+Export-ModuleMember @('Update-FluentDatabase')
+Export-ModuleMember @('Rollback-FluentDatabase')
+Export-ModuleMember @('Add-FluentMigration')

--- a/src/init.ps1
+++ b/src/init.ps1
@@ -18,5 +18,5 @@ if ($importedModule)
 
 if ($import)
 {
-    Import-Module $moduleToImport
+    Import-Module $moduleToImport -DisableNameChecking
 }


### PR DESCRIPTION
New command names: 
- Add-FluentMigration
- Update-FluentDatabase
- Rollback-FluentDatabase

Since 'Rollback' verb is not approved for PowerShell I've to add -DisableNameChecking parameter for package installation.