### PR TITLE
Add Optional Script Parameter to Update-FluentDatabase Function & Rollback-FluentDatabase Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ PM > Update-FluentDatabase -Timeout 120
 
 This command will revert all migrations to specified version (migration number).
 
+
+#### Parameters
+* **-Script** -  optional. Specifies whether you only want to get the script and not run it.
+* **-Timeout** - optional. The waiting time that is established. Default value **30** seconds.
+
 ```console
 PM > Rollback-FluentDatabase 20191207220215
 ```
+
+

--- a/README.md
+++ b/README.md
@@ -106,9 +106,16 @@ namespace DbMigrations.Migrations
 This command will apply all recently created migrations.
 
 ```console
-PM > Update-FluentDatabase
+PM > Update-FluentDatabase [[-Script]] [[-Timeout]<int>]
 ```
-You can specify **-Timeout** parameter if your migration take a lot of time. Default value **30** seconds.
+
+#### Parameters
+* **-Script** -  optional. Specifies whether you only want to get the script and not run it.
+* **-Timeout** - optional. The waiting time that is established. Default value **30** seconds.
+
+
+If your migration takes a long time and you need to extend it, you can specify -Timeout parameter to 120
+
 ```console
 PM > Update-FluentDatabase -Timeout 120
 ```

--- a/src/Alt.FluentMigrator.VStudio.nuspec
+++ b/src/Alt.FluentMigrator.VStudio.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata minClientVersion="3.3.0">
     <id>Alt.FluentMigrator.VStudio</id>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <authors>Volodymyr Liashenko</authors>
     <projectUrl>https://github.com/crimcol/Alt.FluentMigrator.VStudio</projectUrl>
     <license type="expression">MIT</license>

--- a/src/Alt.FluentMigrator.VStudio.psd1
+++ b/src/Alt.FluentMigrator.VStudio.psd1
@@ -3,7 +3,7 @@
     RootModule = 'Alt.FluentMigrator.VStudio.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.3.3.0'
+    ModuleVersion = '1.3.4.0'
 
     # ID used to uniquely identify this module
     GUID = '93DE7F00-BB79-422C-9FC8-9EB37E4B7033'

--- a/src/Alt.FluentMigrator.VStudio.psd1
+++ b/src/Alt.FluentMigrator.VStudio.psd1
@@ -3,7 +3,7 @@
     RootModule = 'Alt.FluentMigrator.VStudio.psm1'
 
     # Version number of this module.
-    ModuleVersion = '1.3.2.0'
+    ModuleVersion = '1.3.3.0'
 
     # ID used to uniquely identify this module
     GUID = '93DE7F00-BB79-422C-9FC8-9EB37E4B7033'

--- a/src/Alt.FluentMigrator.VStudio.psm1
+++ b/src/Alt.FluentMigrator.VStudio.psm1
@@ -168,7 +168,9 @@ function Rollback-FluentDatabase
 		param ([parameter(Position = 0, Mandatory = $true)]
 			[string] $MigrationNumber,
 			[String] $ProjectName, 
-			[Int] $Timeout = 30)
+			[Int] $Timeout = 30,
+		    [Switch]$Script
+		)
 
 	$migrationProject = GetProjectProperties $ProjectName
 	FluentBuild $migrationProject.Project
@@ -186,8 +188,12 @@ function Rollback-FluentDatabase
 		"-a ""$($migrationProject.OutputFileFullPath)""",
 		"-wd ""$($migrationProject.OutputFullPath)""",
 		"-timeout $($Timeout)")
-	
-	$command = "$($migrationSettings.FluentMigrationToolPath) $params"
+
+	if ($Script) {
+        $params += "-p", "-o"
+    }
+
+	$command = "$($migrationSettings.FluentMigrationToolPath) $($params -join ' ')"
 
 	Write-Host $command
 	Invoke-Expression -Command $command

--- a/src/Alt.FluentMigrator.VStudio.psm1
+++ b/src/Alt.FluentMigrator.VStudio.psm1
@@ -127,30 +127,40 @@ function GetProjectProperties
 
 function Update-FluentDatabase
 {
-	[CmdletBinding()]
-		param ([String]$ProjectName, [Int] $Timeout = 30)
+    [CmdletBinding()]
+    param (
+        [String]$ProjectName,
+        [Int]$Timeout = 30,
+        [Switch]$Script
+    )
 
-	$migrationProject = GetProjectProperties $ProjectName
-	FluentBuild $migrationProject.Project
+    $migrationProject = GetProjectProperties $ProjectName
+    FluentBuild $migrationProject.Project
 
-	$migrationSettings = GetMigrationSettings $migrationProject.Name
-	$connectionProject = GetProjectProperties $migrationSettings.ConnectionProjectName
-	$connectionString = ReadConnectionString $connectionProject.ConfigFilePath $migrationSettings.ConnectionName
+    $migrationSettings = GetMigrationSettings $migrationProject.Name
+    $connectionProject = GetProjectProperties $migrationSettings.ConnectionProjectName
+    $connectionString = ReadConnectionString $connectionProject.ConfigFilePath $migrationSettings.ConnectionName
 
-	$params = @(
-		"-t:migrate", 
-		"-db $($migrationSettings.DbProvider)",
-		#"-configPath ""$($connectionProject.ConfigFilePath)""",
-		"-c ""$($connectionString)""",
-		"-a ""$($migrationProject.OutputFileFullPath)""",
-		"-wd ""$($migrationProject.OutputFullPath)""",
-		"-timeout $($Timeout)",
-		"-verbose ""TRUE""")
-	$command = "$($migrationSettings.FluentMigrationToolPath) $params"
-	
-	Write-Host $command
-	Invoke-Expression -Command $command
+    $params = @(
+        "-t:migrate", 
+        "-db $($migrationSettings.DbProvider)",
+        "-c ""$($connectionString)""",
+        "-a ""$($migrationProject.OutputFileFullPath)""",
+        "-wd ""$($migrationProject.OutputFullPath)""",
+        "-timeout $($Timeout)",
+        "-verbose ""TRUE"""
+    )
+
+    if ($Script) {
+        $params += "-p", "-o"
+    }
+
+    $command = "$($migrationSettings.FluentMigrationToolPath) $($params -join ' ')"
+
+    Write-Host $command
+    Invoke-Expression -Command $command
 }
+
 
 function Rollback-FluentDatabase
 {


### PR DESCRIPTION
This pull request introduces a new optional parameter called "Script" to the Update-FluentDatabase & Rollback-FluentDatabase Function functions in the PowerShell script. When this parameter is specified, it enables the execution of FluentMigrator with the -p and -o options, allowing the generation of SQL scripts without executing them. This enhancement provides more flexibility and control over the database migration process.